### PR TITLE
refactor(cl_handlers): remove client side entity deletion

### DIFF
--- a/client/cl_handlers.lua
+++ b/client/cl_handlers.lua
@@ -25,23 +25,3 @@ for _, eventName in pairs(_blockedClientEvents) do
         Triggered = true
     end)
 end
-
-local function clearObjects()
-  local objects = GetGamePool('CObject')
-  for i = 1, #objects do
-
-    local handle = objects[i]
-
-    repeat
-      NetworkRequestControlOfEntity(handle)
-    until NetworkHasControlOfEntity(handle)
-
-    if IsEntityAttached(handle) then
-      DetachEntity(handle, false, false)
-    end
-
-    DeleteEntity(handle)
-  end
-end
-
-RegisterNetEvent('vac_clear_objects', clearObjects)

--- a/server/sv_commands.lua
+++ b/server/sv_commands.lua
@@ -34,8 +34,8 @@ RegisterCommand('unban', function(source, args)
 end, true)
 
 RegisterCommand('clearo', function()
-  for _, netId in pairs(GetPlayers()) do
-    TriggerClientEvent('vac_clear_objects', netId)
+  for _, object in pairs(GetAllObjects()) do
+    DeleteEntity(object)
   end
 end, true)
 


### PR DESCRIPTION
Hi there,

I don't think we should use clientside to delete objects.
We are actually going to produce weird loops of NetworkHasControlOfEntity that shouldn't happen.

This part of the code could be done on the server-side like other commands.